### PR TITLE
Added storage and removal of subscription to chatroom messages

### DIFF
--- a/src/app/chatbox/chatbox.component.ts
+++ b/src/app/chatbox/chatbox.component.ts
@@ -21,6 +21,7 @@ import { User } from '../models/user.model';
 import { Chat } from '../models/chat.model';
 import { UserInfo } from 'firebase';
 import { Chatuser } from '../models/chatuser.model';
+import { Subscription } from 'rxjs';
 // import randomString from 'randomstring';
 
 @Component({
@@ -31,6 +32,7 @@ import { Chatuser } from '../models/chatuser.model';
 export class ChatboxComponent implements OnInit {
   @Input() userInfo: User;
   selectedChatRoomID = 'UgQEVNxekZrld8UJqtkZ';
+  chatroomSubscription: Subscription;
   text: string;
   message = '';
   messages: string[] = [];
@@ -122,7 +124,7 @@ export class ChatboxComponent implements OnInit {
 
   updateChatHistory() {
     this.events = [];
-    this.chatRoomService
+    this.chatroomSubscription = this.chatRoomService
       .getUpdates(this.selectedChatRoomID)
       .subscribe((message: any) => {
         console.log(message);
@@ -171,6 +173,7 @@ export class ChatboxComponent implements OnInit {
   }
 
   openConversation(index: number) {
+    this.chatroomSubscription.unsubscribe();
     this.selectedConversation.members[0].userID = this.friendList[index].id;
     this.selectedConversation.members[0].name = this.friendList[index].name;
     this.selectedChatRoomID = this.conversationsListId[index];


### PR DESCRIPTION
#### Description
Previously the chatrooms where sending multiple messages depending on the number of times the chatroom was opened/clicked. This was caused by subscribing to the chatroom messages but not unsubscribing when opening a new chatroom. Added logic that stores and unsubscribes from subscriptions for currently opened chatroom.

#### Testing
- `ng build` + `npm start`
- tested locally that the intended changes were produced