### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,13 +1,14 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a report of a bug
 title: ''
-labels: ''
+labels: 'bug'
 assignees: ''
 
 ---
 
 **Describe the bug**
+
 
 **To Reproduce**
 
@@ -15,11 +16,8 @@ assignees: ''
 **Expected behavior**
 
 
-**Screenshots**
+**Screenshots/GIF of behavior**
 
-
-**Desktop (please complete the following information):**
- - OS: 
- - Browser:
 
 **Additional context**
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,31 +8,18 @@ assignees: ''
 ---
 
 **Describe the bug**
-A clear and concise description of what the bug is.
 
 **To Reproduce**
-Steps to reproduce the behavior:
 
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
 
 
 **Screenshots**
-If applicable, add screenshots to help explain your problem.
 
 
 **Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
-
-
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
-
+ - OS: 
+ - Browser:
 
 **Additional context**
-Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,16 +8,12 @@ assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
 
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
 
 
 **Additional context**
-Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+---
+name: pull request
+about: Suggest an implementation for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your pull request related to an issue?**
+
+
+**What does your pull request do?**
+
+
+**What more do you believe needs to be added?**
+
+

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,5 @@ assignees: ''
 **What does your pull request do?**
 
 
-**What more do you believe needs to be added?**
-
+**Screenshot/GIF demonstrating your implementation**
 


### PR DESCRIPTION
currently there are no templates for issues. lets add them?
It will look like this:
![issue template](https://user-images.githubusercontent.com/12496046/69014154-49029e80-0955-11ea-8521-cdb85e299d24.PNG)

This is part of github Community Guidelines:
https://help.github.com/en/github/building-a-strong-community