### PR TITLE
Added method to UserInfo service to retrieve user by email

### DIFF
--- a/src/app/models/UserNotFoundError.ts
+++ b/src/app/models/UserNotFoundError.ts
@@ -1,0 +1,5 @@
+export class UserNotFoundError extends Error {
+    constructor(public message: string) {
+        super(message);
+    }
+}

--- a/src/app/models/user.model.ts
+++ b/src/app/models/user.model.ts
@@ -6,4 +6,5 @@ export interface User {
     myCustomData?: string;
     friendList: string[];
     chatrooms: string[];
+    chatroomsRef?: string[];
 }

--- a/src/app/services/user-info.service.ts
+++ b/src/app/services/user-info.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
-import { AngularFirestore } from '@angular/fire/firestore';
+import { AngularFirestore, DocumentReference, QueryDocumentSnapshot, QuerySnapshot } from '@angular/fire/firestore';
 import { map } from 'rxjs/operators';
+import { User } from '../models/user.model';
+import { UserNotFoundError } from '../models/UserNotFoundError';
 @Injectable({
   providedIn: 'root'
 })
@@ -26,5 +28,27 @@ export class UserInfoService {
   // and respond.payload.id to achieve id
   public getCurrentUserInfo(userID: string) {
     return this.db.doc(`users/${userID}`).snapshotChanges();
+  }
+
+  /**
+   * Returns a promise that resolves if a user exists with the specified email
+   * @param email The email of the user
+   * @returns A Promise<User> of the requested user
+   */
+  public getUserByEmail(email: string): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.db.collection('users').ref
+      .where('email', '==', email)
+      .get()
+      .then((querySnapshot: QuerySnapshot<User>) => {
+        if (querySnapshot.size === 0) {
+          reject(new UserNotFoundError(`User with email: (${email}) does not exist`));
+        } else {
+          querySnapshot.forEach((userDocumentSnapshot: QueryDocumentSnapshot<User>) => {
+            resolve(userDocumentSnapshot.data());
+          });
+        }
+      });
+    });
   }
 }

--- a/src/app/tests/services/user-info.service.spec.ts
+++ b/src/app/tests/services/user-info.service.spec.ts
@@ -2,6 +2,8 @@ import { TestBed } from '@angular/core/testing';
 import { AngularFirestore } from '@angular/fire/firestore';
 import { UserInfoService } from '../../services/user-info.service';
 import { of } from 'rxjs';
+import { User } from 'src/app/models/user.model';
+import { UserNotFoundError } from 'src/app/models/UserNotFoundError';
 
 let service: UserInfoService;
 
@@ -96,4 +98,55 @@ describe('UserInfoService.getCurrentUserInfo()', () => {
     mockReturn.payload.id = 'modified id';
     expect(respond.payload.id).toEqual('modified id');
   });
+});
+
+describe('UserInfoService.getUserByEmail()', () => {
+  const USER_EMAIL = 'email';
+  const USER_INFO = {
+    uid: 'uid',
+    email: USER_EMAIL,
+    friendList: ['friend1', 'friend2'],
+    chatrooms: ['chatroomID1', 'chatroomID2']
+  };
+  const RESOLVED_PROMISE_WITH_USER_INFO = Promise.resolve([{
+    data(): User { return USER_INFO; }
+  }]);
+  const USER_NOT_FOUND_ERROR = new UserNotFoundError('Email not found');
+  const REJECTED_PROMISE_WITH_ERROR = Promise.reject(USER_NOT_FOUND_ERROR);
+
+  let serviceUnderTest: UserInfoService;
+  let mockObject: jasmine.SpyObj<any>;
+  let firestoreServiceSpy: jasmine.SpyObj<AngularFirestore>;
+
+  firestoreServiceSpy = jasmine.createSpyObj('FirestoreService', ['collection']);
+  mockObject = jasmine.createSpyObj('MockObject', ['ref', 'where', 'get']);
+
+  firestoreServiceSpy.collection.withArgs(jasmine.any(String)).and.returnValue(mockObject);
+  mockObject.ref = mockObject;
+  mockObject.where.withArgs(jasmine.any(String), jasmine.any(String), jasmine.any(String)).and.returnValue(mockObject);
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+          UserInfoService,
+          { provide: AngularFirestore, useValue: firestoreServiceSpy }
+        ],
+    });
+  });
+
+  it('calling getUserByEmail() SHOULD resolve IF email exists', () => {
+    mockObject.get.and.returnValue(RESOLVED_PROMISE_WITH_USER_INFO);
+    serviceUnderTest = TestBed.get(UserInfoService);
+    serviceUnderTest.getUserByEmail(USER_EMAIL).then((userInfo) => {
+      expect(userInfo).toEqual(USER_INFO);
+    });
+  });
+  it('calling getUserByEmail() SHOULD reject IF email does not exist', () => {
+    mockObject.get.and.returnValue(REJECTED_PROMISE_WITH_ERROR);
+    serviceUnderTest = TestBed.get(UserInfoService);
+    serviceUnderTest.getUserByEmail(USER_EMAIL).catch((e: UserNotFoundError) => {
+      expect(e).toEqual(USER_NOT_FOUND_ERROR);
+    });
+  });
+
 });


### PR DESCRIPTION
#### Revision 2
Squashed commits.

#### Description
Added `getUserByEmail()` to UserService for retrieving user information by email. This service will be called when a user is added to a room to confirm that the user exists.

#### Testing
- `ng build` and `npm start`
- `getUserByEmail()` returned the expected output when manually tested with actual email input