### PR TITLE
ToneAnalyzer integration into Chitty-Chat system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2666,6 +2666,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "requires": {
+        "object-assign": "^4",
+        "vary": "^1"
+      }
+    },
     "cosmiconfig": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
@@ -7199,8 +7208,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-component": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-browser-dynamic": "~8.0.1",
     "@angular/router": "~8.0.1",
     "@types/jquery": "^3.3.31",
+    "cors": "^2.8.5",
     "express": "^4.17.1",
     "firebase": "^7.3.0",
     "hammerjs": "^2.0.8",

--- a/src/app/chatbox/chatbox.component.ts
+++ b/src/app/chatbox/chatbox.component.ts
@@ -121,16 +121,13 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
       message
     )
     .then((chatID) => {
-      this.updateToneInFirebase(this.selectedChatRoomID, localStorage.getItem('chatID'), message);
+      this.updateToneInFirebase(this.selectedChatRoomID, chatID, message);
     });
   }
 
   updateToneInFirebase(chatRoomID: string, chatID: string, message: string) {
     this.toneAnalyzerService.toneAnalyze(message).subscribe((res: any) => {
       let highestScore = 0.0;
-      // console.log('============== Tone Analyzer response ================');
-      // console.log(res);
-      // console.log('============== Tone Analyzer response ================');
       if (Object.keys(res.tones).length > 0) {
         for (let i = 0; i < Object.keys(res).length; i++) {
           const obj = res.tones[i];

--- a/src/app/chatbox/chatbox.component.ts
+++ b/src/app/chatbox/chatbox.component.ts
@@ -13,7 +13,7 @@ import { Chatuser } from '../models/chatuser.model';
 import { CreateChannelComponent } from '../createchannel/createchannel.component';
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
-import {ToneAnalyzerService} from '../services/tone-analyzer.service'
+import {ToneAnalyzerService} from '../services/tone-analyzer.service';
 
 @Component({
   selector: 'app-chatbox',
@@ -60,7 +60,7 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
     private messageService: MessageService,
     private userInfoService: UserInfoService,
     private chatRoomService: ChatroomService,
-    private toneAnalyzerService : ToneAnalyzerService
+    private toneAnalyzerService: ToneAnalyzerService
   ) { }
 
   ngOnInit() {
@@ -124,7 +124,7 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
     this.updateToneInFirebase(this.selectedChatRoomID, localStorage.getItem('chatID'), message);
   }
 
-  updateToneInFirebase(chatRoomID : string, chatID : string, message: string) {
+  updateToneInFirebase(chatRoomID: string, chatID: string, message: string) {
     this.toneAnalyzerService.toneAnalyze(message).subscribe((res: any) => {
       let highestScore = 0.0;
       // console.log('============== Tone Analyzer response ================');
@@ -139,8 +139,8 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
           }
         }
       }
-      console.log('selected tone : ',this.toneWithHighestScore);
-      this.messageService.updateChatTone(this.selectedChatRoomID, chatID,this.toneWithHighestScore);
+      console.log('selected tone : ', this.toneWithHighestScore);
+      this.messageService.updateChatTone(chatRoomID, chatID, this.toneWithHighestScore);
 
     });
   }

--- a/src/app/chatbox/chatbox.component.ts
+++ b/src/app/chatbox/chatbox.component.ts
@@ -119,9 +119,10 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
       date,
       this.selectedChatRoomID,
       message
-    );
-
-    this.updateToneInFirebase(this.selectedChatRoomID, localStorage.getItem('chatID'), message);
+    )
+    .then((chatID) => {
+      this.updateToneInFirebase(this.selectedChatRoomID, localStorage.getItem('chatID'), message);
+    });
   }
 
   updateToneInFirebase(chatRoomID: string, chatID: string, message: string) {
@@ -205,3 +206,4 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
       });
   }
 }
+

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -10,24 +10,30 @@ export class MessageService {
 
   public sendMessage(
     userID: string, when: Date, chatRoomID: string,
-    content: string, tone: string = 'angry'): void {
+    content: string, tone: string = 'angry'): Promise<any> {
     console.log(`Sending message for userID: ${userID}, when: ${when},
                 chatRoomID: ${chatRoomID}, content: ${content}, emotion: ${tone}`);
-    const chatID = this.db.createId();
-    localStorage.setItem('chatID', chatID);
-    this.db
-      .collection(`chatrooms/${chatRoomID}/chats`)
-      .doc(chatID)
-      .set({
-        content,
-        emotion: tone,
-        tone_id: tone,
-        user: userID,
-        when
+
+    return new Promise((resolve, reject) => {
+      const chatID = this.db.createId();
+      localStorage.setItem('chatID', chatID);
+      this.db
+        .collection(`chatrooms/${chatRoomID}/chats`)
+        .doc(chatID)
+        .set({
+          content,
+          tone_id: tone,
+          user: userID,
+          when
       })
-      .then((data) => {
-        console.log('Message successfully sent!');
+      .then(() => {
+        // console.log('Message sent successfully!', chatID);
+        return resolve(chatID);
+      })
+      .catch(error => {
+        return reject(error);
       });
+    });
   }
 
   public updateChatTone(

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -30,6 +30,22 @@ export class MessageService {
       });
   }
 
+  public updateChatTone(
+    chatRoomID: string,
+    chatID: string,
+    tone: string): void {
+    console.log(`updating tone of chatID: ${chatID} chatRoomID: ${chatRoomID}
+                 new tone: ${tone}`);
 
+    this.db
+      .collection(`chatrooms/${chatRoomID}/chats`)
+      .doc(chatID)
+      .update({
+        tone_id: tone,
+      })
+      .then((data) => {
+        console.log('tone successfully updated!');
+      });
+  }
 
 }

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -13,9 +13,11 @@ export class MessageService {
     content: string, tone: string = 'angry'): void {
     console.log(`Sending message for userID: ${userID}, when: ${when},
                 chatRoomID: ${chatRoomID}, content: ${content}, emotion: ${tone}`);
+    const chatID = this.db.createId();
+    localStorage.setItem('chatID', chatID);
     this.db
       .collection(`chatrooms/${chatRoomID}/chats`)
-      .doc(this.db.createId())
+      .doc(chatID)
       .set({
         content,
         emotion: tone,
@@ -27,5 +29,7 @@ export class MessageService {
         console.log('Message successfully sent!');
       });
   }
+
+
 
 }

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -10,7 +10,7 @@ export class MessageService {
 
   public sendMessage(
     userID: string, when: Date, chatRoomID: string,
-    content: string, tone: string = 'angry'): Promise<any> {
+    content: string, tone: string = 'empty'): Promise<any> {
     console.log(`Sending message for userID: ${userID}, when: ${when},
                 chatRoomID: ${chatRoomID}, content: ${content}, emotion: ${tone}`);
 

--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -16,7 +16,6 @@ export class MessageService {
 
     return new Promise((resolve, reject) => {
       const chatID = this.db.createId();
-      localStorage.setItem('chatID', chatID);
       this.db
         .collection(`chatrooms/${chatRoomID}/chats`)
         .doc(chatID)
@@ -27,7 +26,6 @@ export class MessageService {
           when
       })
       .then(() => {
-        // console.log('Message sent successfully!', chatID);
         return resolve(chatID);
       })
       .catch(error => {

--- a/src/app/services/tone-analyzer.service.ts
+++ b/src/app/services/tone-analyzer.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ToneAnalyzerService {
+
+  uri = 'http://localhost:3000/api';
+
+  constructor(private http: HttpClient) { }
+
+  toneAnalyze(data) {
+    return this.http.post(`${this.uri}/tone`, { text: data });
+  }
+
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,12 +1,18 @@
-let express = require('express')
-let path = require('path');
-let http = require('http');
-let socketIO = require('socket.io');
+const express = require('express'),
+  path = require('path'),
+  http = require('http'),
+  socketIO = require('socket.io'),
+  bodyParser = require('body-parser'),
+  cors = require('cors');
 
-let app = express();
-let server = http.Server(app);
-let io = socketIO(server);
+const toneRoute = require('./routes/tone.route');
 
+const app = express();
+const server = http.Server(app);
+const io = socketIO(server);
+app.use(bodyParser.json());
+app.use(cors());
+app.use('/api', toneRoute);
 const port = process.env.PORT || 3000;
 app.use(express.static(path.join(__dirname, '../../dist/chitty-chat/')))
 

--- a/src/server/package-lock.json
+++ b/src/server/package-lock.json
@@ -4,6 +4,42 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/async": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-2.4.2.tgz",
+      "integrity": "sha512-bWBbC7VG2jdjbgZMX0qpds8U/3h3anfIqE81L8jmVrgFZw/urEDnBA78ymGGKTTK6ciBXmmJ/xlok+Re41S8ww=="
+    },
+    "@types/csv-stringify": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@types/csv-stringify/-/csv-stringify-1.4.3.tgz",
+      "integrity": "sha512-vfbvOBhuTjDYQjdG8dCxLjOsyQMjCE0oN0bIUkJtiolqkCe1WTCjh36w4hEhtkdLHUgsB4aN4r6SFD8iLJgiGQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/extend": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha512-R1g/VyKFFI2HLC1QGAeTtCBWCo6n75l41OnsVYNbmKG+kempOESaodf6BeJyUM3Q0rKa/NQcTHbB2+66lNnxLw=="
+    },
+    "@types/file-type": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/file-type/-/file-type-5.2.2.tgz",
+      "integrity": "sha512-GWtM4fyqfb+bec4ocpo51/y4x0b83Je+iA6eV131LT9wL0//G+1UgwbkMg7w61ceOwR+KkZXK00z44jrrNljWg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/isstream": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@types/isstream/-/isstream-0.1.0.tgz",
+      "integrity": "sha512-jo6R5XtVMgu1ej3H4o9NXiUE/4ZxyxmDrGslGiBa4/ugJr+Olw2viio/F2Vlc+zrwC9HJzuApOCCVC2g5jqV0w=="
+    },
+    "@types/node": {
+      "version": "11.15.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.2.tgz",
+      "integrity": "sha512-BqCU9uIFkUH9Sgo2uLYbmIiFB1T+VBiM8AI/El3LIAI5KzwtckeSG+3WOYZr9aMoX4UIvRFBWBeSaOu6hFue2Q=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -28,10 +64,32 @@
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
       "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+    },
+    "axios": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+      "requires": {
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      }
     },
     "backo2": {
       "version": "1.0.2",
@@ -78,6 +136,11 @@
         "type-is": "~1.6.17"
       }
     },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+    },
     "bytes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
@@ -87,6 +150,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
+    },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+    },
+    "combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "component-bind": {
       "version": "1.0.0",
@@ -134,6 +210,11 @@
         "ms": "2.0.0"
       }
     },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -143,6 +224,19 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
       "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+    },
+    "dotenv": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
@@ -287,6 +381,16 @@
         "vary": "~1.1.2"
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
+    "file-type": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
+      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ=="
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -299,6 +403,34 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
+    "form-data": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -336,6 +468,71 @@
         "toidentifier": "1.0.0"
       }
     },
+    "ibm-cloud-sdk-core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-1.3.0.tgz",
+      "integrity": "sha512-OhymKbjsST64/JRlLErRFDuJ5zvkOUkexjHTm5ux3lCMIlo1aq6bg0HOJMHoI0aKsKmSjDwQ+S0D+nJs7QfiyQ==",
+      "requires": {
+        "@types/extend": "~3.0.0",
+        "@types/file-type": "~5.2.1",
+        "@types/isstream": "^0.1.0",
+        "@types/node": "~10.14.19",
+        "axios": "^0.18.0",
+        "camelcase": "^5.3.1",
+        "debug": "^4.1.1",
+        "dotenv": "^6.2.0",
+        "extend": "~3.0.2",
+        "file-type": "^7.7.1",
+        "form-data": "^2.3.3",
+        "isstream": "~0.1.2",
+        "jsonwebtoken": "^8.5.1",
+        "lodash.isempty": "^4.4.0",
+        "mime-types": "~2.1.18",
+        "object.omit": "~3.0.0",
+        "object.pick": "~1.3.0",
+        "semver": "^6.2.0",
+        "vcap_services": "~0.3.4"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.14.22",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
+          "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw=="
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "ibm-watson": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ibm-watson/-/ibm-watson-5.1.0.tgz",
+      "integrity": "sha512-MzOfuRi9gplqZkXANiFseAJtGjXCJiR7357ywOTbgcAnAf7twPLyYWVS65D13WutfYaW0FuUXqc6MYEWG37P3A==",
+      "requires": {
+        "@types/async": "^2.4.2",
+        "@types/csv-stringify": "^1.4.3",
+        "@types/extend": "^3.0.1",
+        "@types/isstream": "^0.1.0",
+        "@types/node": "^11.9.4",
+        "async": "^2.6.2",
+        "axios": "^0.18.0",
+        "camelcase": "^5.3.1",
+        "extend": "~3.0.2",
+        "ibm-cloud-sdk-core": "^1.0.0",
+        "isstream": "~0.1.2",
+        "websocket": "^1.0.28"
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -359,10 +556,139 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
       "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
+    "is-buffer": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+    },
+    "is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "requires": {
+        "is-plain-object": "^2.0.4"
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+    },
     "isarray": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
       "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+    },
+    "isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "lodash": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+    },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -402,6 +728,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    },
     "negotiator": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
@@ -411,6 +742,22 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+    },
+    "object.omit": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-3.0.0.tgz",
+      "integrity": "sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==",
+      "requires": {
+        "is-extendable": "^1.0.0"
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "requires": {
+        "isobject": "^3.0.1"
+      }
     },
     "on-finished": {
       "version": "2.3.0",
@@ -485,6 +832,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
     },
     "send": {
       "version": "0.17.1",
@@ -672,6 +1024,14 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -687,6 +1047,22 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "vcap_services": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/vcap_services/-/vcap_services-0.3.4.tgz",
+      "integrity": "sha1-FUv5QEAlEqzKI98iY/xg72aEWto="
+    },
+    "websocket": {
+      "version": "1.0.30",
+      "resolved": "https://registry.npmjs.org/websocket/-/websocket-1.0.30.tgz",
+      "integrity": "sha512-aO6klgaTdSMkhfl5VVJzD5fm+Srhh5jLYbS15+OiI1sN6h/RU/XW6WN9J1uVIpUKNmsTvT3Hs35XAFjn9NMfOw==",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.14.0",
+        "typedarray-to-buffer": "^3.1.5",
+        "yaeti": "^0.0.6"
+      }
+    },
     "ws": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.0.tgz",
@@ -699,6 +1075,11 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yeast": {
       "version": "0.1.2",

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.17.1",
+    "ibm-watson": "^5.1.0",
     "socket.io": "^2.3.0"
   }
 }

--- a/src/server/routes/tone.route.js
+++ b/src/server/routes/tone.route.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const app = express();
+const toneRoutes = express.Router();
+const cors = require('cors');
+
+const ToneAnalyzerV3 = require('ibm-watson/tone-analyzer/v3');
+const { IamAuthenticator } = require('ibm-watson/auth');
+
+const toneAnalyzer = new ToneAnalyzerV3({
+  authenticator: new IamAuthenticator({ apikey: 'N0BnOIYWXCogNU_YT40O4U3Io4OY2U4hnlK7va7RMS5O' }),
+  version: '2017-09-21',
+  url: 'https://gateway.watsonplatform.net/tone-analyzer/api/'
+});
+
+var corsOptions = {
+    origin: '*',
+    optionsSuccessStatus: 200
+};
+
+toneRoutes.route('/tone').post(function(req, res) {
+    console.log('original text: ' + req.body.text);
+    toneAnalyzer.tone({
+      toneInput: req.body.text,
+      contentType: 'text/plain'
+    })
+    .then(response => {
+      res.json(response.result.document_tone);
+    })
+    .catch(err => {
+      console.log(err);
+    });
+});
+
+module.exports = toneRoutes;


### PR DESCRIPTION
**description**
- updated the sendMessage() -> removed emotion field, used promise
- added new func updateChatTone() -> that updates the tone of a chat 
- set up a back-end for the toneAnalyzer
- connected back-end with front-end (ref: toneAnalyzer service)
- modified - so a chat tone is updated in the firestore using the updateChatTone() right after sending the new chat.

**test**
**need to do `npm install` in `src/server`**
run the app in the localhost, add a new chat message, check firestore for the tone_id of that chat message. 