### PR TITLE
Implemented feature of adding users to chatroom

### DIFF
--- a/src/app/chatbox/chatbox.component.html
+++ b/src/app/chatbox/chatbox.component.html
@@ -59,18 +59,17 @@
             </p>
           </mat-list-item>
         </mat-list>
-        <mat-form-field class="full-width" (keyup.enter)="addUserByEmail(email)">
+        <mat-form-field class="full-width" (keyup.enter)="addUserByEmail(inputtedEmail)">
             <input
               class="input__field"
               matInput
               placeholder="addperson@example.com"
               name="email"
-              [(ngModel)]="email"
+              [(ngModel)]="inputtedEmail"
             />
             <mat-icon
               matSuffix
-              (click)="addUserByEmail(email)"
-              (keyup)="$event.keyCode == 13 && addUserByEmail(email)"
+              (click)="addUserByEmail(inputtedEmail)"
               >person_add</mat-icon
             >
           </mat-form-field>

--- a/src/app/chatbox/chatbox.component.spec.ts
+++ b/src/app/chatbox/chatbox.component.spec.ts
@@ -9,11 +9,15 @@ import { AuthService } from '../services/auth.service';
 import { environment } from 'src/environments/environment';
 import { AngularFireModule } from '@angular/fire';
 import { AngularFireAuth } from '@angular/fire/auth';
-import { AngularFirestoreModule, AngularFirestore } from '@angular/fire/firestore';
+import { AngularFirestore } from '@angular/fire/firestore';
 import { RouterTestingModule } from '@angular/router/testing';
 import { UserInfoService } from '../services/user-info.service';
+import { ChatroomService } from '../services/chatroom.service';
+import { Subscription } from 'rxjs';
 
 describe('ChatboxComponent', () => {
+  const INVALID_EMAIL = '  ';
+  const VALID_EMAIL_REGISTERED = 'Registered@gmail.com';
   const CHATROOM1_ID = 'chatroomID1';
   const CHATROOM1_NAME = 'chatroomName1';
   const CHATROOM2_ID = 'chatroomID2';
@@ -27,12 +31,30 @@ describe('ChatboxComponent', () => {
     chatroomRefs: []
   });
   const REJECTED_PROMISE_EMAIL_NOT_FOUND: Promise<any> = Promise.reject();
+  const USER_INFO = {
+    uid: 'userID'
+  };
+  const SELECTED_CHATROOM_ID = 'selectedChatroomID';
 
   let componentUnderTest: ChatboxComponent;
   let fixture: ComponentFixture<ChatboxComponent>;
   let userInfoServiceSpy: jasmine.SpyObj<UserInfoService>;
+  let chatroomServiceSpy: jasmine.SpyObj<ChatroomService>;
+  let mockSubscription: jasmine.SpyObj<Subscription>;
+  let mockObject: jasmine.SpyObj<any>;
 
-  userInfoServiceSpy = jasmine.createSpyObj('UserInfoService', ['getUserByEmail']);
+  userInfoServiceSpy = jasmine.createSpyObj(
+    'UserInfoService',
+    ['getUserByEmail', 'getUserList']);
+  chatroomServiceSpy = jasmine.createSpyObj(
+    'ChatroomService',
+    ['addUserToChatroom']);
+  mockSubscription = jasmine.createSpyObj(
+    'MockSubscription',
+    ['unsubscribe']);
+  mockObject = jasmine.createSpyObj(
+    'MockObject',
+    ['subscribe']);
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -49,7 +71,8 @@ describe('ChatboxComponent', () => {
       ],
       declarations: [ChatboxComponent],
       providers: [AuthService, AngularFireAuth, AngularFirestore,
-        { provide: UserInfoService, useValue: userInfoServiceSpy}],
+        { provide: UserInfoService, useValue: userInfoServiceSpy},
+        { provide: ChatroomService, useValue: chatroomServiceSpy}],
     }).compileComponents();
   }));
 
@@ -57,6 +80,10 @@ describe('ChatboxComponent', () => {
     TestBed.get(UserInfoService)
       .getUserByEmail.withArgs(jasmine.any(String))
       .and.returnValue(RESOLVED_PROMISE_WITH_CHATROOMS);
+    TestBed.get(UserInfoService)
+      .getUserList.withArgs(jasmine.any(String))
+      .and.returnValue(mockObject);
+
     fixture = TestBed.createComponent(ChatboxComponent);
     componentUnderTest = fixture.componentInstance;
     componentUnderTest.userInfo = {
@@ -65,6 +92,8 @@ describe('ChatboxComponent', () => {
       friendList: ['friendID1', 'friendID2'],
       chatrooms: ['chatroomID1', 'chatroomID2']
     };
+    componentUnderTest.selectedChatRoomID = SELECTED_CHATROOM_ID;
+    componentUnderTest.userListSubscription = mockSubscription;
     fixture.detectChanges();
   });
 
@@ -103,6 +132,27 @@ describe('ChatboxComponent', () => {
     componentUnderTest.getChatroomList().catch((e) => {
       expect(e).toEqual(jasmine.any(Error));
 
+    });
+  });
+
+  it('calling addUserByEmail() SHOULD reject IF email is invalid', () => {
+    componentUnderTest.addUserByEmail(INVALID_EMAIL).catch((e) => {
+      expect(e).toBeUndefined();
+    });
+  });
+
+  it('calling addUserByEmail() SHOULD resolve IF email exists', () => {
+    TestBed.get(UserInfoService)
+      .getUserByEmail.withArgs(jasmine.any(String))
+      .and.returnValue(Promise.resolve(USER_INFO));
+    TestBed.get(ChatroomService)
+      .addUserToChatroom.withArgs(jasmine.any(String), jasmine.any(String))
+      .and.returnValue(Promise.resolve());
+    spyOn(componentUnderTest, 'updateUserList');
+    componentUnderTest.addUserByEmail(VALID_EMAIL_REGISTERED).then(() => {
+      expect(userInfoServiceSpy.getUserByEmail).toHaveBeenCalled();
+      expect(chatroomServiceSpy.addUserToChatroom).toHaveBeenCalled();
+      expect(componentUnderTest.updateUserList).toHaveBeenCalled();
     });
   });
 

--- a/src/app/chatbox/chatbox.component.ts
+++ b/src/app/chatbox/chatbox.component.ts
@@ -14,6 +14,7 @@ import { CreateChannelComponent } from '../createchannel/createchannel.component
 import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { Subscription } from 'rxjs';
 import {ToneAnalyzerService} from '../services/tone-analyzer.service';
+import { isNull } from 'util';
 
 @Component({
   selector: 'app-chatbox',
@@ -35,6 +36,8 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
   secretCode = 'secret';
   friendListId = [];
   roomName: string;
+  validEmailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))/.source
+    + /@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.source;
 
   conversationsListId = [
     '05kbCceCnYxcfOxewCJK',
@@ -234,7 +237,7 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
    * @returns Promise that resolves if the email exists and user is successfully added
    */
   addUserByEmail(email: string): Promise<any> {
-    if (email && email.trim().length > 0) {
+    if (email && this.validateEmail(email)) {
       return this.userInfoService.getUserByEmail(email)
         .then((userInfo: any) => {
           this.chatRoomService.addUserToChatroom(userInfo.uid, this.selectedChatRoomID)
@@ -273,6 +276,10 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
             });
         });
       });
+  }
+
+  private validateEmail(email: string): boolean {
+    return !isNull(email.match(this.validEmailRegex));
   }
 
 }

--- a/src/app/chatbox/chatbox.component.ts
+++ b/src/app/chatbox/chatbox.component.ts
@@ -36,6 +36,7 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
   secretCode = 'secret';
   friendListId = [];
   roomName: string;
+  inputtedEmail: '';
   validEmailRegex = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))/.source
     + /@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/.source;
 
@@ -242,6 +243,7 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
         .then((userInfo: any) => {
           this.chatRoomService.addUserToChatroom(userInfo.uid, this.selectedChatRoomID)
             .then(() => {
+              this.inputtedEmail = '';
               this.updateUserList();
             });
         });
@@ -256,6 +258,7 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
    * @todo Unit test
    */
   updateUserList() {
+    this.inputtedEmail = '';
     if (this.userListSubscription) {
       this.userListSubscription.unsubscribe();
     }


### PR DESCRIPTION
#### Revision 3
- Added binding of inputted email to `ChatboxComponent.inputtedEmail`
- User email input field clears when a next chatroom is selected or when a user is successfully added

#### Revision 2
Added regex based email checker

#### Description
Implemented `ChatboxComponent.addUserByEmail()` which is triggered when adding users to a chatroom

#### Testing
- `ng build` and `npm start`
- locally tested the adding of users to chatrooms