### PR TITLE
Removed reference from root package.json of server package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "hammerjs": "^2.0.8",
     "moment": "^2.24.0",
     "rxjs": "~6.4.0",
-    "server": "file:src/server",
     "socket.io-client": "^2.3.0",
     "tslib": "^1.9.0",
     "zone.js": "~0.9.1"


### PR DESCRIPTION
#### Description
Deployment was failing during docker image building because the root _package.json_ referenced _src/server/package.json_ before it was loaded.

#### Testing
- `ng build` & `npm start`
- local build of docker image