### PR TITLE
Modified tone analyzer requests in prod environment to use https

### DIFF
--- a/src/app/services/tone-analyzer.service.ts
+++ b/src/app/services/tone-analyzer.service.ts
@@ -7,14 +7,10 @@ import { environment } from 'src/environments/environment';
 })
 export class ToneAnalyzerService {
 
-  uri = environment.production ?
-    'http://ec2-184-72-105-146.compute-1.amazonaws.com' :
-    'http://localhost:3000';
-
   constructor(private http: HttpClient) { }
 
   toneAnalyze(data) {
-    return this.http.post(`${this.uri}/api/tone`, { text: data });
+    return this.http.post(`${environment.uri}/api/tone`, { text: data });
   }
 
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,6 @@
 export const environment = {
   production: true,
+  uri: 'https://chat.chitty-chat.com',
   firebase: {
     apiKey: 'AIzaSyD-9drCjUDfcRit3vaqTkY_8PVZCOsfiiA',
     authDomain: 'chitty-chat-ba34b.firebaseapp.com',

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,6 +4,7 @@
 
 export const environment = {
   production: false,
+  uri: 'http://localhost:3000',
   firebase: {
     apiKey: 'AIzaSyD-9drCjUDfcRit3vaqTkY_8PVZCOsfiiA',
     authDomain: 'chitty-chat-ba34b.firebaseapp.com',


### PR DESCRIPTION
#### Description
Requests from our secured site was failing because the request to the backend api was not through a secure HTTPS endpoint. Added HTTPS to the production environment endpoint.

#### Testing
`ng build` and `npm start`