### PR TITLE
'none' bug fixed and emoji list updated

### DIFF
--- a/src/app/chatbox/chatbox.component.ts
+++ b/src/app/chatbox/chatbox.component.ts
@@ -250,6 +250,10 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
         return '&#128533;';
       case 'empty':
         return '&#128526;';
+      case 'none':
+        return '&#127812;';
+      case 'analytical':
+          return '&#129488;';
     }
   }
 
@@ -293,6 +297,7 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
   updateToneInFirebase(message: string) {
     this.toneAnalyzerService.toneAnalyze(message).subscribe((res: any) => {
       let highestScore = 0.0;
+      this.toneWithHighestScore = 'none';
       if (Object.keys(res.tones).length > 0) {
         for (let i = 0; i < Object.keys(res).length; i++) {
           const obj = res.tones[i];


### PR DESCRIPTION
***updates***
- ****[bug][fixed]**** tone was not being updated to the `default tone='none'`. So, it would just return the previous tone whenever a tone was analyzed as `none`
- there were some repeating emojis for some tones. those are fixed and also added the new tone `analytical` in the emoji list. 

***sample***
[bug]
![image](https://user-images.githubusercontent.com/17440230/69752211-bd3ffd80-111e-11ea-8c60-3d2d7cbde948.png)
[fixed version]
![image](https://user-images.githubusercontent.com/17440230/69752269-d5178180-111e-11ea-854a-3eaa1a1cbdd9.png)
[analytical emoji]
![image](https://user-images.githubusercontent.com/17440230/69752318-e6608e00-111e-11ea-83e0-62e252c82677.png)


***test***
`ng build && npm start`