### PR TITLE
Fixed bug so that the tone with the highest score is selected.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,7 @@ speed-measure-plugin.json
 # misc
 /.sass-cache
 /connect.lock
-coverage
-!coverage/chitty-chat/index.html
+/coverage
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/src/app/chatbox/chatbox.component.ts
+++ b/src/app/chatbox/chatbox.component.ts
@@ -298,12 +298,11 @@ export class ChatboxComponent implements OnInit, AfterViewChecked {
     this.toneAnalyzerService.toneAnalyze(message).subscribe((res: any) => {
       let highestScore = 0.0;
       this.toneWithHighestScore = 'none';
-      if (Object.keys(res.tones).length > 0) {
-        for (let i = 0; i < Object.keys(res).length; i++) {
-          const obj = res.tones[i];
-          if (obj.score > highestScore) {
-            this.toneWithHighestScore = obj.tone_id;
-            highestScore = obj.score;
+      if (res.tones.length > 0) {
+        for (const tone of res.tones) {
+          if (tone.score > highestScore) {
+            this.toneWithHighestScore = tone.tone_id;
+            highestScore = tone.score;
           }
         }
       }


### PR DESCRIPTION
#### Description
- Fixed bug that caused the first of the returned tones to be displayed instead of the tone with the highest score.
- Removed tracking of _index.html_ file in coverage directory

#### Testing
- `ng build`and `npm start`
- tested locally 