### PR TITLE
Modified deleteChatroom service to return a resolved promise on success

### DIFF
--- a/src/app/services/chatroom.service.ts
+++ b/src/app/services/chatroom.service.ts
@@ -124,9 +124,8 @@ export class ChatroomService {
    */
   public deleteChatroom(chatroomID: string): Promise<any> {
     const chatroomRef = this.db.doc(`chatrooms/${chatroomID}`).ref;
-    return new Promise((resolve, reject) => {
-      // delele all sub documents inside this chatroom
-      chatroomRef.collection('chats').get()
+    // delele all sub documents inside this chatroom
+    return chatroomRef.collection('chats').get()
       .then(docs => {
         const batch = this.db.firestore.batch();
         docs.forEach(doc => {
@@ -138,8 +137,7 @@ export class ChatroomService {
       .then(() => chatroomRef.delete())
       // delete all chatroom refs in users
       .then(() => this.delChatroomRefInUsers(chatroomRef))
-      .catch(e => reject('failed!'));
-    });
+      .catch(e => Promise.reject('failed!'));
   }
 
   /**


### PR DESCRIPTION
#### Description
Previously chaining calls with a successful `ChatroomService.deleteChatroom()` did not work because `ChatroomService.deleteChatroom()` did not explicitly resolve when the operation succeeded. Modify the function to return a resolved `Promise` on success.

#### Testing
`ng test`